### PR TITLE
Remove top instructions and persist session score with reset control

### DIFF
--- a/src/components/LetterPictureMatchGame.tsx
+++ b/src/components/LetterPictureMatchGame.tsx
@@ -4,12 +4,18 @@ import { getRandomElement, shuffleArray } from '../utils/arrayUtils'; // Adjust 
 import { GameState, gameReducer, initialState, ExerciseType } from '../state/gameReducer'; // Adjust path
 import { ScoreDisplay } from './ScoreDisplay';
 import { ScoreProgressBar } from './ScoreProgressBar';
-import { InstructionDisplay } from './InstructionDisplay';
 import { FeedbackDisplay } from './FeedbackDisplay';
 import { GameArea } from './GameArea';
 import { NextRoundButton } from './NextRoundButton';
 import { StatsDisplay } from './StatsDisplay';
-import { saveSelection, SelectionRecord, getSelectionHistory } from '../utils/storageUtils'; // Adjust path
+import {
+  saveSelection,
+  SelectionRecord,
+  getSelectionHistory,
+  getSessionScore,
+  resetSessionScore,
+  saveSessionScore,
+} from '../utils/storageUtils'; // Adjust path
 import { calculateLetterWeights, getWeightedRandomLetter } from '../utils/spacedRepetitionUtils'; // Adjust path
 import { ConfettiManager } from './ConfettiManager'; // Import the new manager
 import { letterDotPatterns } from '../utils/letterDotPatterns';
@@ -36,6 +42,11 @@ export function LetterPictureMatch({ letterGroups, availableLetters, isRecording
   const hasQueuedIdlePreload = useRef(false);
 
   const handleToggleStats = () => setShowStats(prev => !prev);
+  const handleStartNewSession = () => {
+    resetSessionScore();
+    dispatch({ type: 'SET_SCORE', payload: 0 });
+    startNewRound();
+  };
 
   // --- Game Logic Callbacks ---
   const startNewRound = useCallback(() => {
@@ -414,6 +425,9 @@ export function LetterPictureMatch({ letterGroups, availableLetters, isRecording
 
   // --- Effects ---
   useEffect(() => {
+    const storedSessionScore = getSessionScore();
+    dispatch({ type: 'SET_SCORE', payload: storedSessionScore });
+
     if (availableLetters.length > 0) {
       startNewRound();
     } else {
@@ -443,6 +457,10 @@ export function LetterPictureMatch({ letterGroups, availableLetters, isRecording
     enqueueIdleTasks(idleTasks);
     hasQueuedIdlePreload.current = true;
   }, [state.correctImageItem, state.exerciseType, letterGroups]);
+
+  useEffect(() => {
+    saveSessionScore(state.score);
+  }, [state.score]);
 
   useEffect(() => {
     let timer: number | undefined;
@@ -568,7 +586,6 @@ export function LetterPictureMatch({ letterGroups, availableLetters, isRecording
 
         <div className="letter-match-container">
             <ScoreProgressBar score={state.score} />
-            <InstructionDisplay exerciseType={state.exerciseType} />
             <ScoreDisplay score={state.score} ref={scoreDisplayRef} />
             <div className="game-content">
                 <GameArea
@@ -586,6 +603,9 @@ export function LetterPictureMatch({ letterGroups, availableLetters, isRecording
                 </div>
                 <div className="game-controls-container">
                     <NextRoundButton onClick={startNewRound} exerciseType={state.exerciseType} />
+                    <button onClick={handleStartNewSession} className="new-letter-button">
+                        New Session
+                    </button>
                     <button onClick={handleToggleStats} className="new-letter-button">
                         {showStats ? 'Hide Stats' : 'Show Stats'}
                     </button>

--- a/src/state/gameReducer.ts
+++ b/src/state/gameReducer.ts
@@ -34,6 +34,7 @@ export interface GameState {
 
 export type GameAction =
     | { type: 'START_ROUND'; payload: Partial<GameState> }
+    | { type: 'SET_SCORE'; payload: number }
     | { type: 'SELECT_IMAGE'; payload: { selected: GermanLetterItem; isCorrect: boolean } }
     | { type: 'SELECT_LETTER'; payload: { selected: string; isCorrect: boolean } }
     | { type: 'SELECT_WORD'; payload: { selected: string; isCorrect: boolean } }
@@ -74,6 +75,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     switch (action.type) {
         case 'SET_ERROR':
             return { ...initialState, error: action.payload, gameReady: false };
+        case 'SET_SCORE':
+            return { ...state, score: Math.max(0, action.payload) };
         case 'START_ROUND': {
             const isDrawing = action.payload.exerciseType === ExerciseType.DRAWING;
             const isDotTracing = action.payload.exerciseType === ExerciseType.DOT_TRACING;

--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -2,6 +2,7 @@
 // Removed unused import: import { GermanLetterItem } from "./imageUtils";
 
 const STORAGE_KEY = 'germanLearningStats';
+const SESSION_SCORE_STORAGE_KEY = 'germanLearningSessionScore';
 
 // Define the structure for each recorded selection
 export interface SelectionRecord {
@@ -55,4 +56,35 @@ export const clearSelectionHistory = (): void => {
     } catch (error) {
         console.error("Error clearing localStorage:", error);
     }
-}; 
+};
+
+export const getSessionScore = (): number => {
+    try {
+        const storedScore = localStorage.getItem(SESSION_SCORE_STORAGE_KEY);
+        if (!storedScore) {
+            return 0;
+        }
+        const parsedScore = Number(storedScore);
+        return Number.isFinite(parsedScore) && parsedScore >= 0 ? parsedScore : 0;
+    } catch (error) {
+        console.error("Error reading session score from localStorage:", error);
+        return 0;
+    }
+};
+
+export const saveSessionScore = (score: number): void => {
+    try {
+        const safeScore = Number.isFinite(score) && score >= 0 ? score : 0;
+        localStorage.setItem(SESSION_SCORE_STORAGE_KEY, String(safeScore));
+    } catch (error) {
+        console.error("Error writing session score to localStorage:", error);
+    }
+};
+
+export const resetSessionScore = (): void => {
+    try {
+        localStorage.setItem(SESSION_SCORE_STORAGE_KEY, '0');
+    } catch (error) {
+        console.error("Error resetting session score in localStorage:", error);
+    }
+};


### PR DESCRIPTION
### Motivation
- The UI should not show the bilingual (German/English) instruction block at the top of each game screen and the session score should persist across reloads so users can continue a session or reset it explicitly.
- A lightweight way to initialize and reset the in-memory score from persisted state is required so the game can resume or start fresh reliably.

### Description
- Removed the `InstructionDisplay` component from the main game layout so the bilingual instructions no longer appear in `LetterPictureMatch` (`src/components/LetterPictureMatchGame.tsx`).
- Added session score persistence helpers `getSessionScore`, `saveSessionScore`, and `resetSessionScore` using the `germanLearningSessionScore` key in `src/utils/storageUtils.ts`.
- Introduced a `SET_SCORE` action in the reducer and handler in `src/state/gameReducer.ts` to allow initializing/resetting the in-memory score safely.
- Wired hydration and persistence in `LetterPictureMatch`: load stored score on mount, save score on change, and added a **New Session** button that zeros stored score, dispatches `SET_SCORE(0)`, and starts a fresh round (`src/components/LetterPictureMatchGame.tsx`).

### Testing
- Ran `npm run lint` and it passed with a pre-existing warning in `DotTraceCanvas.tsx` about hook deps (no new lint errors).
- Ran `npm run test -- --run` and the Vitest suite failed due to two pre-existing failing assertions in `src/utils/imageUtils.test.ts` unrelated to these changes (tests show failures in `processImageModules`).
- Ran `npm run build` which completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e482708a508328a0d9f2860b211b65)